### PR TITLE
MLSS-2502 | initial templates repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+.idea
+composer.lock

--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # BuphaloTemplates
 A collection of versioned, re-usable templates, annotation processors, and utility classes for Buphalo. 
+
+## Oragnization
+Because code is constantly evolving, supporting many different versions of templates may be necessary at a single time.
+To facilitate this, this repo is heavily versioned by PHP Version and Internval Version.
+
+Each every object should be stored in the following pattern:
+
+- Top Level Directory (`src/`, `fab/`, or `templates/`)
+  - PHP Version (_e.g._ `Php81/` for things that work in PHP 8.1+)
+    - 1+ Levels of Object Group (_e.g._ `ClassDefinition/`, `AnnotationProcessors/Prefab8/`)
+      - Internal Version (_e.g._ `V1/`)
+        - Individual Files

--- a/bin/fab/buphalo
+++ b/bin/fab/buphalo
@@ -1,0 +1,9 @@
+echo;
+
+echo "\xF0\x9F\x90\x83 Buphaloing V2 fabrication files in src/";
+Neighborhoods_Buphalo_V2_TargetApplication_BuilderInterface__SourceDirectoryPath=$PWD/src \
+Neighborhoods_Buphalo_V2_TargetApplication_BuilderInterface__FabricationDirectoryPath=$PWD/fab \
+Neighborhoods_Buphalo_V2_TargetApplication_BuilderInterface__NamespacePrefix=Neighborhoods\\BuphaloTemplates\\ \
+Neighborhoods_Buphalo_V2_TemplateTree_Map_Builder_FactoryInterface__TemplateTreeDirectoryPaths=$PWD/templates/ \
+vendor/neighborhoods/buphalo/bin/v2/buphalo;
+echo;

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "neighborhoods/buphalo-templates",
+    "description": "A collection of versioned, re-usable templates, annotation processors, and utility classes for Buphalo.",
+    "type": "library",
+    "license": "MIT",
+    "autoload": {
+        "psr-4": {
+            "Neighborhoods\\BuphaloTemplates\\": ["src/", "fab/"]
+        }
+    },
+    "authors": [
+        {
+            "name": "Jacques Marcotte",
+            "email": "jacques.marcotte@neighborhoods.com"
+        }
+    ],
+    "require": {
+        "neighborhoods/buphalo": "^2.0"
+    }
+}

--- a/fab/Php81/ClassDefinition/V1/ClassDefinition.php
+++ b/fab/Php81/ClassDefinition/V1/ClassDefinition.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1;
+
+final class ClassDefinition implements ClassDefinitionInterface
+{
+
+    private readonly \Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Constant\SetInterface $constants;
+
+    private readonly \Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Property\SetInterface $properties;
+
+    private readonly ?string $identity_field;
+
+    public function getConstants(): \Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Constant\SetInterface
+    {
+        return $this->constants; // Will throw if not initialized
+    }
+
+    public function setConstants(\Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Constant\SetInterface $constants): self
+    {
+        $this->constants = $constants; // Will throw if already initialized
+        return $this;
+    }
+
+    public function getProperties(): \Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Property\SetInterface
+    {
+        return $this->properties; // Will throw if not initialized
+    }
+
+    public function setProperties(\Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Property\SetInterface $properties): self
+    {
+        $this->properties = $properties; // Will throw if already initialized
+        return $this;
+    }
+
+    public function getIdentityField(): ?string
+    {
+        return $this->identity_field; // Will throw if not initialized
+    }
+
+    public function setIdentityField(?string $identity_field): self
+    {
+        $this->identity_field = $identity_field; // Will throw if already initialized
+        return $this;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/fab/Php81/ClassDefinition/V1/ClassDefinitionInterface.php
+++ b/fab/Php81/ClassDefinition/V1/ClassDefinitionInterface.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1;
+
+interface ClassDefinitionInterface 
+    extends \JsonSerializable
+{
+    public const PROP_CONSTANTS = 'constants';
+    public const PROP_PROPERTIES = 'properties';
+    public const PROP_IDENTITY_FIELD = 'identity_field';
+
+    public function getConstants(): \Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Constant\SetInterface;
+    public function setConstants(\Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Constant\SetInterface $constants): self;
+
+    public function getProperties(): \Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Property\SetInterface;
+    public function setProperties(\Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Property\SetInterface $properties): self;
+
+    public function getIdentityField(): ?string;
+    public function setIdentityField(?string $identity_field): self;
+}

--- a/fab/Php81/ClassDefinition/V1/Constant.php
+++ b/fab/Php81/ClassDefinition/V1/Constant.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1;
+
+final class Constant implements ConstantInterface
+{
+
+    private readonly string $name;
+
+    private readonly mixed $value;
+
+    public function getName(): string
+    {
+        return $this->name; // Will throw if not initialized
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name; // Will throw if already initialized
+        return $this;
+    }
+
+    public function getValue(): mixed
+    {
+        return $this->value; // Will throw if not initialized
+    }
+
+    public function setValue(mixed $value): self
+    {
+        $this->value = $value; // Will throw if already initialized
+        return $this;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/fab/Php81/ClassDefinition/V1/Constant/CollectionInterface.php
+++ b/fab/Php81/ClassDefinition/V1/Constant/CollectionInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Constant;
+
+interface CollectionInterface extends \JsonSerializable, \IteratorAggregate
+{
+    public function getIterator(): \Traversable;
+
+    public function toArray(): array;
+}

--- a/fab/Php81/ClassDefinition/V1/Constant/Set.php
+++ b/fab/Php81/ClassDefinition/V1/Constant/Set.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Constant;
+
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ConstantInterface;
+
+final class Set implements SetInterface
+{
+    private array $data = [];
+
+    // Initialization Methods
+
+    public function __construct(ConstantInterface ...$values)
+    {
+        $this->add(...$values);
+    }
+
+    public function hydrate(ConstantInterface ...$values): SetInterface
+    {
+        if (!$this->isEmpty()) {
+            throw new \LogicException('String Set is not empty');
+        }
+
+        $this->__construct(...$values);
+
+        return $this;
+    }
+
+
+    // Mutators
+
+    public function add(ConstantInterface ...$values): SetInterface
+    {
+        foreach ($values as $value) {
+            $this->data[$this->getIdentifier($value)] = $value;
+        }
+
+        return $this;
+    }
+
+    public function remove(ConstantInterface ...$values): SetInterface
+    {
+        foreach ($values as $value) {
+            unset($this->data[$this->getIdentifier($value)]);
+        }
+
+        return $this;
+    }
+
+    public function clear(): SetInterface
+    {
+        $this->data = [];
+
+        return $this;
+    }
+
+
+    // Inspectors
+
+    public function contains(ConstantInterface $value): bool
+    {
+        return isset($this->data[$this->getIdentifier($value)]);
+    }
+
+    public function containsAll(ConstantInterface ...$values): bool
+    {
+        foreach ($values as $value) {
+            if (!$this->contains($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function containsAny(ConstantInterface ...$values): bool
+    {
+        if (!\count($values)) {
+            throw new \InvalidArgumentException('ContainsAny requires at least one value to search for.');
+        }
+
+        foreach ($values as $value) {
+            if ($this->contains($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function count(): int
+    {
+        return \count($this->data);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->count() === 0;
+    }
+
+
+    // Operations that return a new Set
+
+    public function copy(): SetInterface
+    {
+        return new self(...$this);
+    }
+
+    public function diff(SetInterface $other): SetInterface
+    {
+        return $this->filter(
+            static function ($element) use ($other) {
+                return !$other->contains($element);
+            }
+        );
+    }
+
+    public function filter(callable $callback): SetInterface
+    {
+        $filtered = new self();
+
+        foreach($this as $value) {
+            $shouldInclude = $callback($value);
+            if ($shouldInclude === true) {
+                $filtered->add($value);
+            } elseif ($shouldInclude !== false) {
+                throw new \TypeError('Filter callback MUST return boolean');
+            }
+        }
+
+        return $filtered;
+    }
+
+    public function intersect(SetInterface $other): SetInterface
+    {
+        return $this->filter(
+            static function ($element) use ($other) {
+                return $other->contains($element);
+            }
+        );
+    }
+
+    public function map(callable $callback): SetInterface
+    {
+        $mapped = new self();
+        foreach ($this as $value) {
+            $mapped->add($callback($value));
+        }
+
+        return $mapped;
+    }
+
+    public function union(SetInterface $other): SetInterface
+    {
+        $union = $this->copy();
+        $union->add(...$other);
+
+        return $union;
+    }
+
+    public function xor(SetInterface $other): SetInterface
+    {
+        return $this->union($other)->filter(
+            function ($element) use ($other) {
+                return $this->contains($element) xor $other->contains($element);
+            }
+        );
+    }
+
+    // Other Operations
+
+    public function reduce(callable $callback, $initial)
+    {
+        $carry = $initial;
+
+        foreach ($this as $value) {
+            $carry = $callback($carry, $value);
+        }
+
+        return $carry;
+    }
+
+    public function toArray(): array
+    {
+        return array_values($this->data);
+    }
+
+    public function getIterator(): \Traversable
+    {
+        foreach ($this->data as $value) {
+            yield $value;
+        }
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    private function getIdentifier(ConstantInterface $value): string
+    {
+        return $value->getName();
+    }
+}

--- a/fab/Php81/ClassDefinition/V1/Constant/SetInterface.php
+++ b/fab/Php81/ClassDefinition/V1/Constant/SetInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Constant;
+
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ConstantInterface;
+
+interface SetInterface extends CollectionInterface
+{
+    // Initialization
+    public function hydrate(ConstantInterface ...$values): SetInterface;
+
+    // Mutators
+    public function add(ConstantInterface ...$values): SetInterface;
+
+    public function remove(ConstantInterface ...$values): SetInterface;
+
+    public function clear(): SetInterface;
+
+    // Inspectors
+    public function contains(ConstantInterface $value): bool;
+
+    public function containsAll(ConstantInterface ...$values): bool;
+
+    public function containsAny(ConstantInterface ...$values): bool;
+
+    /* @see \Countable::count() */
+    public function count(): int;
+
+    public function isEmpty(): bool;
+
+    public function copy(): SetInterface;
+
+    public function diff(SetInterface $other): SetInterface;
+
+    public function filter(callable $callback): SetInterface;
+
+    public function intersect(SetInterface $other): SetInterface;
+
+    public function map(callable $callback): SetInterface;
+
+    public function union(SetInterface $other): SetInterface;
+
+    public function xor(SetInterface $other): SetInterface;
+
+    // Operations that return something else
+    public function reduce(callable $callback, $initial);
+}

--- a/fab/Php81/ClassDefinition/V1/ConstantInterface.php
+++ b/fab/Php81/ClassDefinition/V1/ConstantInterface.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1;
+
+interface ConstantInterface 
+    extends \JsonSerializable
+{
+    public const PROP_NAME = 'name';
+    public const PROP_VALUE = 'value';
+
+    public function getName(): string;
+    public function setName(string $name): self;
+
+    public function getValue(): mixed;
+    public function setValue(mixed $value): self;
+}

--- a/fab/Php81/ClassDefinition/V1/Property.php
+++ b/fab/Php81/ClassDefinition/V1/Property.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1;
+
+final class Property implements PropertyInterface
+{
+
+    private readonly string $name;
+
+    private readonly string $data_type;
+
+    public function getName(): string
+    {
+        return $this->name; // Will throw if not initialized
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name; // Will throw if already initialized
+        return $this;
+    }
+
+    public function getDataType(): string
+    {
+        return $this->data_type; // Will throw if not initialized
+    }
+
+    public function setDataType(string $data_type): self
+    {
+        $this->data_type = $data_type; // Will throw if already initialized
+        return $this;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/fab/Php81/ClassDefinition/V1/Property/CollectionInterface.php
+++ b/fab/Php81/ClassDefinition/V1/Property/CollectionInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Property;
+
+interface CollectionInterface extends \JsonSerializable, \IteratorAggregate
+{
+    public function getIterator(): \Traversable;
+
+    public function toArray(): array;
+}

--- a/fab/Php81/ClassDefinition/V1/Property/Set.php
+++ b/fab/Php81/ClassDefinition/V1/Property/Set.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Property;
+
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\PropertyInterface;
+
+final class Set implements SetInterface
+{
+    private array $data = [];
+
+    // Initialization Methods
+
+    public function __construct(PropertyInterface ...$values)
+    {
+        $this->add(...$values);
+    }
+
+    public function hydrate(PropertyInterface ...$values): SetInterface
+    {
+        if (!$this->isEmpty()) {
+            throw new \LogicException('String Set is not empty');
+        }
+
+        $this->__construct(...$values);
+
+        return $this;
+    }
+
+
+    // Mutators
+
+    public function add(PropertyInterface ...$values): SetInterface
+    {
+        foreach ($values as $value) {
+            $this->data[$this->getIdentifier($value)] = $value;
+        }
+
+        return $this;
+    }
+
+    public function remove(PropertyInterface ...$values): SetInterface
+    {
+        foreach ($values as $value) {
+            unset($this->data[$this->getIdentifier($value)]);
+        }
+
+        return $this;
+    }
+
+    public function clear(): SetInterface
+    {
+        $this->data = [];
+
+        return $this;
+    }
+
+
+    // Inspectors
+
+    public function contains(PropertyInterface $value): bool
+    {
+        return isset($this->data[$this->getIdentifier($value)]);
+    }
+
+    public function containsAll(PropertyInterface ...$values): bool
+    {
+        foreach ($values as $value) {
+            if (!$this->contains($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function containsAny(PropertyInterface ...$values): bool
+    {
+        if (!\count($values)) {
+            throw new \InvalidArgumentException('ContainsAny requires at least one value to search for.');
+        }
+
+        foreach ($values as $value) {
+            if ($this->contains($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function count(): int
+    {
+        return \count($this->data);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->count() === 0;
+    }
+
+
+    // Operations that return a new Set
+
+    public function copy(): SetInterface
+    {
+        return new self(...$this);
+    }
+
+    public function diff(SetInterface $other): SetInterface
+    {
+        return $this->filter(
+            static function ($element) use ($other) {
+                return !$other->contains($element);
+            }
+        );
+    }
+
+    public function filter(callable $callback): SetInterface
+    {
+        $filtered = new self();
+
+        foreach($this as $value) {
+            $shouldInclude = $callback($value);
+            if ($shouldInclude === true) {
+                $filtered->add($value);
+            } elseif ($shouldInclude !== false) {
+                throw new \TypeError('Filter callback MUST return boolean');
+            }
+        }
+
+        return $filtered;
+    }
+
+    public function intersect(SetInterface $other): SetInterface
+    {
+        return $this->filter(
+            static function ($element) use ($other) {
+                return $other->contains($element);
+            }
+        );
+    }
+
+    public function map(callable $callback): SetInterface
+    {
+        $mapped = new self();
+        foreach ($this as $value) {
+            $mapped->add($callback($value));
+        }
+
+        return $mapped;
+    }
+
+    public function union(SetInterface $other): SetInterface
+    {
+        $union = $this->copy();
+        $union->add(...$other);
+
+        return $union;
+    }
+
+    public function xor(SetInterface $other): SetInterface
+    {
+        return $this->union($other)->filter(
+            function ($element) use ($other) {
+                return $this->contains($element) xor $other->contains($element);
+            }
+        );
+    }
+
+    // Other Operations
+
+    public function reduce(callable $callback, $initial)
+    {
+        $carry = $initial;
+
+        foreach ($this as $value) {
+            $carry = $callback($carry, $value);
+        }
+
+        return $carry;
+    }
+
+    public function toArray(): array
+    {
+        return array_values($this->data);
+    }
+
+    public function getIterator(): \Traversable
+    {
+        foreach ($this->data as $value) {
+            yield $value;
+        }
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    private function getIdentifier(PropertyInterface $value): string
+    {
+        return $value->getName();
+    }
+}

--- a/fab/Php81/ClassDefinition/V1/Property/SetInterface.php
+++ b/fab/Php81/ClassDefinition/V1/Property/SetInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Property;
+
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\PropertyInterface;
+
+interface SetInterface extends CollectionInterface
+{
+    // Initialization
+    public function hydrate(PropertyInterface ...$values): SetInterface;
+
+    // Mutators
+    public function add(PropertyInterface ...$values): SetInterface;
+
+    public function remove(PropertyInterface ...$values): SetInterface;
+
+    public function clear(): SetInterface;
+
+    // Inspectors
+    public function contains(PropertyInterface $value): bool;
+
+    public function containsAll(PropertyInterface ...$values): bool;
+
+    public function containsAny(PropertyInterface ...$values): bool;
+
+    /* @see \Countable::count() */
+    public function count(): int;
+
+    public function isEmpty(): bool;
+
+    public function copy(): SetInterface;
+
+    public function diff(SetInterface $other): SetInterface;
+
+    public function filter(callable $callback): SetInterface;
+
+    public function intersect(SetInterface $other): SetInterface;
+
+    public function map(callable $callback): SetInterface;
+
+    public function union(SetInterface $other): SetInterface;
+
+    public function xor(SetInterface $other): SetInterface;
+
+    // Operations that return something else
+    public function reduce(callable $callback, $initial);
+}

--- a/fab/Php81/ClassDefinition/V1/PropertyInterface.php
+++ b/fab/Php81/ClassDefinition/V1/PropertyInterface.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1;
+
+interface PropertyInterface 
+    extends \JsonSerializable
+{
+    public const PROP_NAME = 'name';
+    public const PROP_DATA_TYPE = 'data_type';
+
+    public function getName(): string;
+    public function setName(string $name): self;
+
+    public function getDataType(): string;
+    public function setDataType(string $data_type): self;
+}

--- a/src/Php81/AnnotationProcessors/ClassDefinition/V1/Builder/AdditionalFactories.php
+++ b/src/Php81/AnnotationProcessors/ClassDefinition/V1/Builder/AdditionalFactories.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\AnnotationProcessors\ClassDefinition\V1\Builder;
+
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ClassDefinition\Loader;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\PropertyInterface;
+use Neighborhoods\Buphalo\V2\AnnotationProcessorInterface;
+
+/** @noinspection PhpUnused, PhpSuperClassIncompatibleWithInterfaceInspection */
+final class AdditionalFactories implements AnnotationProcessorInterface
+{
+    use Loader\AwareTrait;
+
+    public function getReplacement(): string
+    {
+        $statements = [];
+
+        foreach ($this->getClassDefinition()->getProperties() as $property) {
+            $statement = $this->buildUseStatement($property);
+            if ($statement !== null) {
+                // keyed to ensure it is a set
+                $statements[$statement] = $statement;
+            }
+        }
+
+        return implode(PHP_EOL, $statements);
+    }
+
+    private function buildUseStatement(PropertyInterface $property): ?string
+    {
+        if (!$this->requiresFactory($property)) {
+            return null;
+        }
+
+        $propertyClass = str_replace('Interface', '', $property->getDataType());
+        $awareTraitClass = $propertyClass . '\\Builder\\Factory\\AwareTrait';
+
+        return "    use $awareTraitClass;";
+    }
+
+    private function requiresFactory(PropertyInterface $property): bool
+    {
+        // preg_match returns 0, 1, or false
+        $intResult = preg_match('/^\\\\Neighborhoods/', $property->getDataType());
+        if ($intResult === false) {
+            throw new \Exception('Error matching Data Type ' . $property->getDataType());
+        }
+
+        return (bool)$intResult;
+    }
+}

--- a/src/Php81/AnnotationProcessors/ClassDefinition/V1/Builder/Build.php
+++ b/src/Php81/AnnotationProcessors/ClassDefinition/V1/Builder/Build.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\AnnotationProcessors\ClassDefinition\V1\Builder;
+
+use Neighborhoods\Buphalo\V2\AnnotationProcessorInterface;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ClassDefinition\Loader;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\PropertyInterface;
+
+/** @noinspection PhpUnused, PhpSuperClassIncompatibleWithInterfaceInspection */
+
+final class Build implements AnnotationProcessorInterface
+{
+    use Loader\AwareTrait;
+
+    private const FORMAT_FETCH_FROM_RECORD = '$record[PrimaryActorNameInterface::PROP_%s]';
+    private const FORMAT_SIMPLE_NULL_FALLBACK = '%s ?? null';
+    private const FORMAT_BUILD_COMPLEX_OBJECT = '$this->get%sBuilderFactory()->create()->setRecord(%s)->build()';
+    private const FORMAT_NULLABLE_COMPLEX = '
+            isset(%s)
+                ? %s
+                : null
+        ';
+
+    private const FORMAT_ASSIGNMENT = '        $PrimaryActorName->set%s(%s);';
+
+    public function getReplacement(): string
+    {
+        $statements = [];
+
+        foreach ($this->getClassDefinition()->getProperties() as $property) {
+            $statements[] = $this->buildSetStatement($property);
+        }
+
+        return implode(PHP_EOL, $statements);
+    }
+
+    private function buildSetStatement(PropertyInterface $property): string
+    {
+        $propertyName = $property->getName();
+
+        $fetchFromRecord = sprintf(self::FORMAT_FETCH_FROM_RECORD, strtoupper($propertyName));
+
+        if ($this->requiresBuilderFactory($property)) {
+            $buildObject = sprintf(
+                self::FORMAT_BUILD_COMPLEX_OBJECT,
+                $this->getMethodName($property),
+                $fetchFromRecord
+            );
+
+            $postFetch = $this->isPropertyNullable($property)
+                ? sprintf(self::FORMAT_NULLABLE_COMPLEX, $fetchFromRecord, $buildObject)
+                : $buildObject;
+        } else {
+            $postFetch = $this->isPropertyNullable($property)
+                ? sprintf(self::FORMAT_SIMPLE_NULL_FALLBACK, $fetchFromRecord)
+                : $fetchFromRecord;
+        }
+
+        $statement = sprintf(self::FORMAT_ASSIGNMENT, $this->getPascalCaseName($propertyName), $postFetch);
+
+        return $statement;
+    }
+
+    private function isPropertyNullable(PropertyInterface $property): bool
+    {
+        return str_starts_with($property->getDataType(), '?');
+    }
+
+    private function getMethodName(PropertyInterface $property): string
+    {
+        $namespace = getenv('Neighborhoods_Buphalo_V2_TargetApplication_BuilderInterface__NamespacePrefix');
+        $typeWithoutNull = preg_replace('/^\\?/', '', $property->getDataType());
+        $typeWithoutVendor = preg_replace('/' . addslashes($namespace) . '/', '', $typeWithoutNull);
+        $typeWithoutInterface = str_replace('Interface', '', $typeWithoutVendor);
+        $typeWithoutSlashes = str_replace('\\', '', $typeWithoutInterface);
+
+        return $typeWithoutSlashes;
+    }
+
+    private function requiresBuilderFactory(PropertyInterface $property): bool
+    {
+        // preg_match returns 0, 1, or false
+        $intResult = preg_match('/^\??\\\\Neighborhoods/', $property->getDataType());
+        if ($intResult === false) {
+            throw new \LogicException('Error matching Data Type ' . $property->getDataType());
+        }
+
+        return (bool)$intResult;
+    }
+
+    private function getPascalCaseName(string $propertyName): string
+    {
+        $words = explode('_', $propertyName);
+        return implode(
+            '',
+            array_map(
+                static function (string $word): string {
+                    return ucfirst($word);
+                },
+                $words
+            )
+        );
+    }
+}

--- a/src/Php81/AnnotationProcessors/ClassDefinition/V1/Builder/ServiceCalls.php
+++ b/src/Php81/AnnotationProcessors/ClassDefinition/V1/Builder/ServiceCalls.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\AnnotationProcessors\ClassDefinition\V1\Builder;
+
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ClassDefinition\Loader;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\PropertyInterface;
+use Neighborhoods\Buphalo\V2\AnnotationProcessorInterface;
+
+/** @noinspection PhpUnused, PhpSuperClassIncompatibleWithInterfaceInspection */
+final class ServiceCalls implements AnnotationProcessorInterface
+{
+    private const FORMAT_CALL = "      - [set%sBuilderFactory, ['@%s']]";
+
+    use Loader\AwareTrait;
+
+    public function getReplacement(): string
+    {
+        $statements = [];
+
+        foreach ($this->getClassDefinition()->getProperties() as $property) {
+            $statement = $this->buildServiceCallStatement($property);
+            if ($statement !== null) {
+                // keyed to ensure it is a set
+                $statements[$statement] = $statement;
+            }
+        }
+
+        return implode(PHP_EOL, $statements);
+    }
+
+    private function buildServiceCallStatement(PropertyInterface $property): ?string
+    {
+        if (!$this->requiresFactory($property)) {
+            return null;
+        }
+
+        $propertyClass = str_replace('Interface', '', $property->getDataType());
+        $propertyClass = preg_replace('/^\\\\/', '', $propertyClass);
+        $builderFactoryServiceReference = $propertyClass . '\\Builder\\FactoryInterface';
+
+        return sprintf(self::FORMAT_CALL, $this->getMethodName($property), $builderFactoryServiceReference);
+    }
+
+    private function requiresFactory(PropertyInterface $property): bool
+    {
+        // preg_match returns 0, 1, or false
+        $intResult = preg_match('/^\\\\Neighborhoods/', $property->getDataType());
+        if ($intResult === false) {
+            throw new \LogicException('Error matching Data Type ' . $property->getDataType());
+        }
+
+        return (bool)$intResult;
+    }
+
+    private function getMethodName(PropertyInterface $property): string
+    {
+        $namespace = getenv('Neighborhoods_Buphalo_V2_TargetApplication_BuilderInterface__NamespacePrefix');
+        $typeWithoutNull = preg_replace('/^\\?/', '', $property->getDataType());
+        $typeWithoutVendor = preg_replace('/' . addslashes($namespace) . '/', '', $typeWithoutNull);
+        $typeWithoutInterface = str_replace('Interface', '', $typeWithoutVendor);
+        $typeWithoutSlashes = str_replace('\\', '', $typeWithoutInterface);
+
+        return $typeWithoutSlashes;
+    }
+}

--- a/src/Php81/AnnotationProcessors/ClassDefinition/V1/ClassPropertiesAndAccessorsByArray.php
+++ b/src/Php81/AnnotationProcessors/ClassDefinition/V1/ClassPropertiesAndAccessorsByArray.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\AnnotationProcessors\ClassDefinition\V1;
+
+use Neighborhoods\Buphalo\V2\AnnotationProcessorInterface;
+use Neighborhoods\Buphalo\V2\AnnotationProcessor\Context;
+
+/** @noinspection PhpUnused */
+class ClassPropertiesAndAccessorsByArray implements AnnotationProcessorInterface
+{
+    use Context\AwareTrait {
+        setAnnotationProcessorContext as public;
+        getAnnotationProcessorContext as public;
+    }
+
+    public const KEY_PROPERTIES = 'properties';
+
+    public const PROPERTY_KEY_DATA_TYPE = 'data_type';
+
+    /*
+     * 1: type
+     * 2: name
+     */
+    private const FORMAT_PROPERTY = '
+    private readonly %1$s $%2$s;';
+
+    /*
+     * 1: Name
+     * 2: type
+     * 3: name
+     */
+    private const FORMAT_GETTER = '
+    public function get%1$s(): %2$s
+    {
+        return $this->%3$s; // Will throw if not initialized
+    }';
+
+    /*
+     * 1: Name
+     * 2: type
+     * 3: name
+     */
+    private const FORMAT_SETTER = '
+    public function set%1$s(%2$s $%3$s): self
+    {
+        $this->%3$s = $%3$s; // Will throw if already initialized
+        return $this;
+    }';
+
+    public function getReplacement(): string
+    {
+        $properties = [];
+        $accessors = [];
+
+        $context = $this->getAnnotationProcessorContext()->getStaticContextRecord();
+        foreach ($context[self::KEY_PROPERTIES] as $name => $propertyDetails) {
+            $properties[] = $this->buildProperty($name, $propertyDetails);
+            $accessors[] = $this->buildAccessors($name, $propertyDetails);
+        }
+
+        return implode(PHP_EOL, $properties) . PHP_EOL . implode(PHP_EOL, $accessors);
+    }
+
+    private function buildProperty(string $name, array $propertyDetails): string
+    {
+        return sprintf(self::FORMAT_PROPERTY, $propertyDetails[self::PROPERTY_KEY_DATA_TYPE], $name);
+    }
+
+    private function buildAccessors(string $propertyName, array $propertyDetails): string
+    {
+        $accessors = [
+            $this->buildGetter($propertyName, $propertyDetails),
+            $this->buildSetter($propertyName, $propertyDetails),
+        ];
+
+        return implode(PHP_EOL, $accessors);
+    }
+
+    private function buildGetter(string $propertyName, array $propertyDetails): string
+    {
+        return sprintf(
+            self::FORMAT_GETTER,
+            $this->getPascalCaseName($propertyName),
+            $propertyDetails[self::PROPERTY_KEY_DATA_TYPE],
+            $propertyName,
+        );
+    }
+
+    private function buildSetter(string $propertyName, array $propertyDetails): string
+    {
+        return sprintf(
+            self::FORMAT_SETTER,
+            $this->getPascalCaseName($propertyName),
+            $propertyDetails[self::PROPERTY_KEY_DATA_TYPE],
+            $propertyName,
+        );
+    }
+
+    private function getPascalCaseName(string $propertyName): string
+    {
+        $words = explode('_', $propertyName);
+        return implode(
+            '',
+            array_map(
+                static function (string $word): string {
+                    return ucfirst($word);
+                },
+                $words
+            )
+        );
+    }
+}

--- a/src/Php81/AnnotationProcessors/ClassDefinition/V1/ClassPropertiesAndAccessorsByFile.php
+++ b/src/Php81/AnnotationProcessors/ClassDefinition/V1/ClassPropertiesAndAccessorsByFile.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\AnnotationProcessors\ClassDefinition\V1;
+
+use Neighborhoods\Buphalo\V2\AnnotationProcessorInterface;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ClassDefinition\Loader;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\PropertyInterface;
+
+/** @noinspection PhpUnused */
+class ClassPropertiesAndAccessorsByFile implements AnnotationProcessorInterface
+{
+    use Loader\AwareTrait;
+
+    /*
+     * 1: type
+     * 2: name
+     */
+    private const FORMAT_PROPERTY = '
+    private readonly %1$s $%2$s;';
+
+    /*
+     * 1: Name
+     * 2: type
+     * 3: name
+     */
+    private const FORMAT_GETTER = '
+    public function get%1$s(): %2$s
+    {
+        return $this->%3$s; // Will throw if not initialized
+    }';
+
+    /*
+     * 1: Name
+     * 2: type
+     * 3: name
+     */
+    private const FORMAT_SETTER = '
+    public function set%1$s(%2$s $%3$s): self
+    {
+        $this->%3$s = $%3$s; // Will throw if already initialized
+        return $this;
+    }';
+
+    public function getReplacement(): string
+    {
+        $properties = [];
+        $accessors = [];
+
+        foreach ($this->getClassDefinition()->getProperties() as $property) {
+            $properties[] = $this->buildProperty($property);
+            $accessors[] = $this->buildAccessors($property);
+        }
+
+        return implode(PHP_EOL, $properties) . PHP_EOL . implode(PHP_EOL, $accessors);
+    }
+
+    private function buildProperty(PropertyInterface $property): string
+    {
+        return sprintf(self::FORMAT_PROPERTY, $property->getDataType(), $property->getName());
+    }
+
+    private function buildAccessors(PropertyInterface $property): string
+    {
+        $accessors = [
+            $this->buildGetter($property),
+            $this->buildSetter($property),
+        ];
+
+        return implode(PHP_EOL, $accessors);
+    }
+
+    private function buildGetter(PropertyInterface $property): string
+    {
+        return sprintf(
+            self::FORMAT_GETTER,
+            $this->getPascalCaseName($property->getName()),
+            $property->getDataType(),
+            $property->getName(),
+        );
+    }
+
+    private function buildSetter(PropertyInterface $property): string
+    {
+        return sprintf(
+            self::FORMAT_SETTER,
+            $this->getPascalCaseName($property->getName()),
+            $property->getDataType(),
+            $property->getName(),
+        );
+    }
+
+    private function getPascalCaseName(string $propertyName): string
+    {
+        $words = explode('_', $propertyName);
+        return implode(
+            '',
+            array_map(
+                static function (string $word): string {
+                    return ucfirst($word);
+                },
+                $words
+            )
+        );
+    }
+
+}

--- a/src/Php81/AnnotationProcessors/ClassDefinition/V1/InterfaceConstantsAndAccessorsByArray.php
+++ b/src/Php81/AnnotationProcessors/ClassDefinition/V1/InterfaceConstantsAndAccessorsByArray.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\AnnotationProcessors\ClassDefinition\V1;
+
+use Neighborhoods\Buphalo\V2\AnnotationProcessor\Context;
+use Neighborhoods\Buphalo\V2\AnnotationProcessorInterface;
+
+/** @noinspection PhpUnused */
+class InterfaceConstantsAndAccessorsByArray implements AnnotationProcessorInterface
+{
+    use Context\AwareTrait {
+        setAnnotationProcessorContext as public;
+        getAnnotationProcessorContext as public;
+    }
+
+    public const KEY_CONSTANTS = 'constants';
+
+    public const KEY_PROPERTIES = 'properties';
+    public const PROPERTY_KEY_DATA_TYPE = 'data_type';
+
+    /*
+     * 1: NAME
+     * 2: 'value'
+     */
+    private const FORMAT_CONSTANT = '    public const %1s = %2s;';
+
+    /*
+     * 1: Name
+     * 2: type
+     */
+    private const FORMAT_GETTER = '    public function get%1$s(): %2$s;';
+
+    /*
+     * 1: Name
+     * 2: type
+     * 3: name
+     */
+    private const FORMAT_SETTER = '    public function set%1$s(%2$s $%3$s): self;';
+
+    public function getReplacement(): string
+    {
+        $constants = [];
+        $accessors = [];
+
+        $context = $this->getAnnotationProcessorContext()->getStaticContextRecord();
+
+
+        if (isset($context[self::KEY_CONSTANTS])) {
+            foreach ($context[self::KEY_CONSTANTS] as $name => $value) {
+                $constants[] = $this->buildUserDefinedConstant($name, $value);
+            }
+        }
+
+        foreach ($context[self::KEY_PROPERTIES] as $name => $details) {
+            $constants[] = $this->buildPropertyConstant($name);
+            $accessors[] = $this->buildAccessors($name, $details);
+        }
+
+        return implode(PHP_EOL, $constants) . PHP_EOL . PHP_EOL . implode(PHP_EOL . PHP_EOL, $accessors);
+    }
+
+    private function buildUserDefinedConstant(string $name, $value): string
+    {
+        $valueString = \is_array($value) ? $this->convertArrayToStringValue($value) : var_export($value, true);
+
+        return sprintf(self::FORMAT_CONSTANT, $name, $valueString);
+    }
+
+    private function buildPropertyConstant(string $name): string
+    {
+        return sprintf(self::FORMAT_CONSTANT, 'PROP_' . strtoupper($name), var_export($name, true));
+    }
+
+    private function convertArrayToStringValue(array $values): string
+    {
+        $arrayItems = [];
+
+        foreach ($values as $key => $value) {
+            if (\is_array($value)) {
+                $valueToAppendToArray = $this->convertArrayToStringValue($value);
+            } else {
+                $valueToAppendToArray = var_export($value, true);
+            }
+
+            if (is_numeric($key)) {
+                $arrayItems[] = $valueToAppendToArray;
+            } else {
+                $arrayItems[] = var_export($key, true) . ' => ' . $valueToAppendToArray;
+            }
+        }
+
+        return '[ ' . implode(', ', $arrayItems) . ']';
+    }
+
+    private function buildAccessors(string $propertyName, array $propertyDetails): string
+    {
+        $accessors = [
+            $this->buildGetter($propertyName, $propertyDetails),
+            $this->buildSetter($propertyName, $propertyDetails),
+        ];
+
+        return implode(PHP_EOL, $accessors);
+    }
+
+    private function buildGetter(string $propertyName, array $propertyDetails): string
+    {
+        return sprintf(
+            self::FORMAT_GETTER,
+            $this->getPascalCaseName($propertyName),
+            $propertyDetails[self::PROPERTY_KEY_DATA_TYPE]
+        );
+    }
+
+    private function buildSetter(string $propertyName, array $propertyDetails): string
+    {
+        return sprintf(
+            self::FORMAT_SETTER,
+            $this->getPascalCaseName($propertyName),
+            $propertyDetails[self::PROPERTY_KEY_DATA_TYPE],
+            $propertyName,
+        );
+    }
+
+    private function getPascalCaseName(string $name): string
+    {
+        $words = explode('_', $name);
+        return implode(
+            '',
+            array_map(
+                static function (string $word): string {
+                    return ucfirst($word);
+                },
+                $words
+            )
+        );
+    }
+}

--- a/src/Php81/AnnotationProcessors/ClassDefinition/V1/InterfaceConstantsAndAccessorsByFile.php
+++ b/src/Php81/AnnotationProcessors/ClassDefinition/V1/InterfaceConstantsAndAccessorsByFile.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\AnnotationProcessors\ClassDefinition\V1;
+
+use Neighborhoods\Buphalo\V2\AnnotationProcessor\Context;
+use Neighborhoods\Buphalo\V2\AnnotationProcessorInterface;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ClassDefinition\Loader;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ConstantInterface;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\PropertyInterface;
+
+/** @noinspection PhpUnused */
+class InterfaceConstantsAndAccessorsByFile implements AnnotationProcessorInterface
+{
+    use Loader\AwareTrait;
+
+    /*
+     * 1: NAME
+     * 2: 'value'
+     */
+    private const FORMAT_CONSTANT = '    public const %1s = %2s;';
+
+    /*
+     * 1: Name
+     * 2: type
+     */
+    private const FORMAT_GETTER = '    public function get%1$s(): %2$s;';
+
+    /*
+     * 1: Name
+     * 2: type
+     * 3: name
+     */
+    private const FORMAT_SETTER = '    public function set%1$s(%2$s $%3$s): self;';
+
+    public function getReplacement(): string
+    {
+        $constants = [];
+        $accessors = [];
+
+        foreach ($this->getClassDefinition()->getConstants() as $constant) {
+            $constants[] = $this->buildUserDefinedConstant($constant);
+        }
+
+        foreach ($this->getClassDefinition()->getProperties() as $property) {
+            $constants[] = $this->buildPropertyConstant($property);
+            $accessors[] = $this->buildAccessors($property);
+        }
+
+        return implode(PHP_EOL, $constants) . PHP_EOL . PHP_EOL . implode(PHP_EOL . PHP_EOL, $accessors);
+    }
+
+    private function buildUserDefinedConstant(ConstantInterface $constant): string
+    {
+        $value = $constant->getValue();
+        $valueString = \is_array($value) ? $this->convertArrayToStringValue($value) : var_export($value, true);
+
+        return sprintf(self::FORMAT_CONSTANT, $constant->getName(), $valueString);
+    }
+
+    private function buildPropertyConstant(PropertyInterface $property): string
+    {
+        $name = $property->getName();
+        return sprintf(self::FORMAT_CONSTANT, 'PROP_' . strtoupper($name), var_export($name, true));
+    }
+
+    private function convertArrayToStringValue(array $values): string
+    {
+        $arrayItems = [];
+
+        foreach ($values as $key => $value) {
+            if (\is_array($value)) {
+                $valueToAppendToArray = $this->convertArrayToStringValue($value);
+            } else {
+                $valueToAppendToArray = var_export($value, true);
+            }
+
+            if (is_numeric($key)) {
+                $arrayItems[] = $valueToAppendToArray;
+            } else {
+                $arrayItems[] = var_export($key, true) . ' => ' . $valueToAppendToArray;
+            }
+        }
+
+        return '[ ' . implode(', ', $arrayItems) . ']';
+    }
+
+    private function buildAccessors(PropertyInterface $property): string
+    {
+        $accessors = [
+            $this->buildGetter($property),
+            $this->buildSetter($property),
+        ];
+
+        return implode(PHP_EOL, $accessors);
+    }
+
+    private function buildGetter(PropertyInterface $property): string
+    {
+        return sprintf(
+            self::FORMAT_GETTER,
+            $this->getPascalCaseName($property->getName()),
+            $property->getDataType()
+        );
+    }
+
+    private function buildSetter(PropertyInterface $property): string
+    {
+        return sprintf(
+            self::FORMAT_SETTER,
+            $this->getPascalCaseName($property->getName()),
+            $property->getDataType(),
+            $property->getName(),
+        );
+    }
+
+    private function getPascalCaseName(string $name): string
+    {
+        $words = explode('_', $name);
+        return implode(
+            '',
+            array_map(
+                static function (string $word): string {
+                    return ucfirst($word);
+                },
+                $words
+            )
+        );
+    }
+}

--- a/src/Php81/AnnotationProcessors/ClassDefinition/V1/InterfaceExtensions.php
+++ b/src/Php81/AnnotationProcessors/ClassDefinition/V1/InterfaceExtensions.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\AnnotationProcessors\ClassDefinition\V1;
+
+use Neighborhoods\Buphalo\V2\AnnotationProcessor\Context;
+use Neighborhoods\Buphalo\V2\AnnotationProcessorInterface;
+
+/** @noinspection PhpUnused */
+class InterfaceExtensions implements AnnotationProcessorInterface
+{
+    use Context\AwareTrait {
+        getAnnotationProcessorContext as public;
+    }
+
+    public function getReplacement(): string
+    {
+        $context = $this->getAnnotationProcessorContext()->getStaticContextRecord();
+        return empty($context) ? '' : 'extends ' . implode(', ', $context);
+    }
+
+}

--- a/src/Php81/ClassDefinition/V1/ClassDefinition.buphalo.v2.fabrication.yml
+++ b/src/Php81/ClassDefinition/V1/ClassDefinition.buphalo.v2.fabrication.yml
@@ -1,0 +1,28 @@
+actors:
+  # Primary Actor
+  <PrimaryActorName>.php:
+    template: Php81/GeneralActors/V1/PrimaryActorName.php
+    annotation_processors:
+      ClassPropertiesAndAccessors:
+        processor_fqcn: \Neighborhoods\BuphaloTemplates\Php81\AnnotationProcessors\ClassDefinition\V1\ClassPropertiesAndAccessorsByArray
+        static_context_record:
+          properties:
+            constants:
+              data_type: \Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Constant\SetInterface
+            properties:
+              data_type: \Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Property\SetInterface
+            identity_field:
+              data_type: ?string
+  <PrimaryActorName>Interface.php:
+    template: Php81/GeneralActors/V1/PrimaryActorNameInterface.php
+    annotation_processors:
+      ClassInterfaceConstantsAndAccessors:
+        processor_fqcn: \Neighborhoods\BuphaloTemplates\Php81\AnnotationProcessors\ClassDefinition\V1\InterfaceConstantsAndAccessorsByArray
+        static_context_record:
+          properties:
+            constants:
+              data_type: \Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Constant\SetInterface
+            properties:
+              data_type: \Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Property\SetInterface
+            identity_field:
+              data_type: ?string

--- a/src/Php81/ClassDefinition/V1/ClassDefinition/Loader.php
+++ b/src/Php81/ClassDefinition/V1/ClassDefinition/Loader.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ClassDefinition;
+
+use Neighborhoods\Buphalo\V2\AnnotationProcessor;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ClassDefinition;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ClassDefinitionInterface;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Constant;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\Property;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\PropertyInterface;
+use Symfony\Component\Yaml\Yaml;
+
+final class Loader implements LoaderInterface
+{
+    use AnnotationProcessor\Context\AwareTrait;
+
+    private readonly ClassDefinitionInterface $class_definition;
+
+    public function __construct(AnnotationProcessor\ContextInterface $context)
+    {
+        $this->setAnnotationProcessorContext($context);
+        $this->loadClassDefinition();
+    }
+
+    private function loadClassDefinition(): LoaderInterface
+    {
+        $fabricationFile = $this->getAnnotationProcessorContext()->getFabricationFile();
+        $directory = $fabricationFile->getDirectoryPath();
+        $fileName = $fabricationFile->getFileName();
+        $parsedDefinitionFileContents = Yaml::parseFile($directory . '/' . $fileName . '.class.definition.yml');
+
+        $classDefinition = $this->buildClassDefinition($parsedDefinitionFileContents);
+        $this->setClassDefinition($classDefinition);
+
+        return $this;
+    }
+
+    private function buildClassDefinition(array $definitionArray): ClassDefinitionInterface
+    {
+        $constants = new Constant\Set();
+        foreach ($definitionArray[ClassDefinitionInterface::PROP_CONSTANTS] ?? [] as $name => $value) {
+            $constant = new Constant();
+            $constant->setName($name)
+                ->setValue($value);
+            $constants->add($constant);
+        }
+
+        $properties = new Property\Set();
+        foreach ($definitionArray[ClassDefinitionInterface::PROP_PROPERTIES] as $name => $details) {
+            $property = new Property();
+            $property->setName($name)
+                ->setDataType($details[PropertyInterface::PROP_DATA_TYPE]);
+            $properties->add($property);
+        }
+
+        $classDefinition = new ClassDefinition();
+        $classDefinition
+            ->setConstants($constants)
+            ->setProperties($properties)
+            ->setIdentityField($definitionArray[ClassDefinitionInterface::PROP_IDENTITY_FIELD] ?? null);
+
+        return $classDefinition;
+    }
+
+    public function getClassDefinition(): ClassDefinitionInterface
+    {
+        try {
+            return $this->class_definition;
+        } catch (\Error) {
+            $this->loadClassDefinition();
+        }
+
+        return $this->class_definition;
+    }
+
+    private function setClassDefinition(ClassDefinitionInterface $class_definition): self
+    {
+        $this->class_definition = $class_definition; // Will throw if already initialized
+        return $this;
+    }
+
+}

--- a/src/Php81/ClassDefinition/V1/ClassDefinition/Loader/AwareTrait.php
+++ b/src/Php81/ClassDefinition/V1/ClassDefinition/Loader/AwareTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ClassDefinition\Loader;
+
+use Neighborhoods\Buphalo\V2\AnnotationProcessor\Context;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ClassDefinition\Loader;
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ClassDefinitionInterface;
+
+trait AwareTrait
+{
+    use Context\AwareTrait {
+        setAnnotationProcessorContext as public;
+        getAnnotationProcessorContext as public;
+    }
+
+    private readonly ClassDefinitionInterface $class_definition;
+
+    private function setClassDefinition(ClassDefinitionInterface $class_definition): self
+    {
+        $this->class_definition = $class_definition; // Will throw if already set
+        return $this;
+    }
+
+    private function loadClassDefinition(): self
+    {
+        $loader = new Loader($this->getAnnotationProcessorContext());
+        $this->setClassDefinition($loader->getClassDefinition());
+        return $this;
+    }
+
+    private function getClassDefinition(): ClassDefinitionInterface
+    {
+        try {
+            return $this->class_definition; // Will throw if uninitialized
+        } catch (\Error) {
+            $this->loadClassDefinition();
+        }
+
+        return $this->class_definition;
+    }
+}

--- a/src/Php81/ClassDefinition/V1/ClassDefinition/LoaderInterface.php
+++ b/src/Php81/ClassDefinition/V1/ClassDefinition/LoaderInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ClassDefinition;
+
+use Neighborhoods\BuphaloTemplates\Php81\ClassDefinition\V1\ClassDefinitionInterface;
+
+interface LoaderInterface
+{
+    public function getClassDefinition(): ClassDefinitionInterface;
+}

--- a/src/Php81/ClassDefinition/V1/Constant.buphalo.v2.fabrication.yml
+++ b/src/Php81/ClassDefinition/V1/Constant.buphalo.v2.fabrication.yml
@@ -1,0 +1,35 @@
+actors:
+  # Primary Actor
+  <PrimaryActorName>.php:
+    template: Php81/GeneralActors/V1/PrimaryActorName.php
+    annotation_processors:
+      ClassPropertiesAndAccessors:
+        processor_fqcn: \Neighborhoods\BuphaloTemplates\Php81\AnnotationProcessors\ClassDefinition\V1\ClassPropertiesAndAccessorsByArray
+        static_context_record:
+          properties:
+            name:
+              data_type: string
+            value:
+              data_type: mixed
+  <PrimaryActorName>Interface.php:
+    template: Php81/GeneralActors/V1/PrimaryActorNameInterface.php
+    annotation_processors:
+      ClassInterfaceConstantsAndAccessors:
+        processor_fqcn: \Neighborhoods\BuphaloTemplates\Php81\AnnotationProcessors\ClassDefinition\V1\InterfaceConstantsAndAccessorsByArray
+        static_context_record:
+          properties:
+            name:
+              data_type: string
+            value:
+              data_type: mixed
+  <PrimaryActorName>/Set.php:
+    template: Php81/GeneralActors/V1/PrimaryActorName/Set.php
+    annotation_processors:
+      Set.getIdentifierContent:
+        processor_fqcn: \Neighborhoods\Buphalo\V2\AnnotationProcessors\SimpleString
+        static_context_record:
+          string: "return $value->getName();"
+  <PrimaryActorName>/SetInterface.php:
+    template: Php81/GeneralActors/V1/PrimaryActorName/SetInterface.php
+  <PrimaryActorName>/CollectionInterface.php:
+    template: Php81/GeneralActors/V1/PrimaryActorName/CollectionInterface.php

--- a/src/Php81/ClassDefinition/V1/Property.buphalo.v2.fabrication.yml
+++ b/src/Php81/ClassDefinition/V1/Property.buphalo.v2.fabrication.yml
@@ -1,0 +1,35 @@
+actors:
+  # Primary Actor
+  <PrimaryActorName>.php:
+    template: Php81/GeneralActors/V1/PrimaryActorName.php
+    annotation_processors:
+      ClassPropertiesAndAccessors:
+        processor_fqcn: \Neighborhoods\BuphaloTemplates\Php81\AnnotationProcessors\ClassDefinition\V1\ClassPropertiesAndAccessorsByArray
+        static_context_record:
+          properties:
+            name:
+              data_type: string
+            data_type:
+              data_type: string
+  <PrimaryActorName>Interface.php:
+    template: Php81/GeneralActors/V1/PrimaryActorNameInterface.php
+    annotation_processors:
+      ClassInterfaceConstantsAndAccessors:
+        processor_fqcn: \Neighborhoods\BuphaloTemplates\Php81\AnnotationProcessors\ClassDefinition\V1\InterfaceConstantsAndAccessorsByArray
+        static_context_record:
+          properties:
+            name:
+              data_type: string
+            data_type:
+              data_type: string
+  <PrimaryActorName>/Set.php:
+    template: Php81/GeneralActors/V1/PrimaryActorName/Set.php
+    annotation_processors:
+      Set.getIdentifierContent:
+        processor_fqcn: \Neighborhoods\Buphalo\V2\AnnotationProcessors\SimpleString
+        static_context_record:
+          string: "return $value->getName();"
+  <PrimaryActorName>/SetInterface.php:
+    template: Php81/GeneralActors/V1/PrimaryActorName/SetInterface.php
+  <PrimaryActorName>/CollectionInterface.php:
+    template: Php81/GeneralActors/V1/PrimaryActorName/CollectionInterface.php

--- a/templates/Php81/GeneralActors/V1/PrimaryActorName.php
+++ b/templates/Php81/GeneralActors/V1/PrimaryActorName.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplateTree\RelativeNamespace;
+
+final class PrimaryActorName implements PrimaryActorNameInterface
+{
+/** @neighborhoods-buphalo:annotation-processor ClassPropertiesAndAccessors
+// TODO: Implement properties, and accessors.
+ */
+
+    public function jsonSerialize(): array
+    {
+        return get_object_vars($this);
+    }
+}

--- a/templates/Php81/GeneralActors/V1/PrimaryActorName/Builder.php
+++ b/templates/Php81/GeneralActors/V1/PrimaryActorName/Builder.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplateTree\RelativeNamespace\PrimaryActorName;
+
+use Neighborhoods\BuphaloTemplateTree\RelativeNamespace\PrimaryActorNameInterface;
+
+class Builder implements BuilderInterface
+{
+    use Factory\AwareTrait;
+/** @neighborhoods-buphalo:annotation-processor Builder.additional_factories
+*/
+
+    private array $record;
+
+    public function build(): PrimaryActorNameInterface
+    {
+        $PrimaryActorName = $this->getNamespacedPrimaryActorNameFactory()->create();
+        $record = $this->getRecord();
+
+/** @neighborhoods-buphalo:annotation-processor Builder.build
+*/
+
+        return $PrimaryActorName;
+    }
+
+    private function getRecord(): array
+    {
+        return $this->record; // will throw if not initialized
+    }
+
+    public function setRecord(array $record): self
+    {
+        $this->record = $record; // will throw if already initialized
+        return $this;
+    }
+}

--- a/templates/Php81/GeneralActors/V1/PrimaryActorName/Builder.service.yml
+++ b/templates/Php81/GeneralActors/V1/PrimaryActorName/Builder.service.yml
@@ -1,0 +1,9 @@
+services:
+  Neighborhoods\BuphaloTemplateTree\RelativeNamespace\PrimaryActorName\BuilderInterface:
+    class: Neighborhoods\BuphaloTemplateTree\RelativeNamespace\PrimaryActorName\Builder
+    public: false
+    shared: false
+    calls:
+      - [setNamespacedPrimaryActorNameFactory, ['@Neighborhoods\BuphaloTemplateTree\RelativeNamespace\PrimaryActorName\FactoryInterface']]
+/** @neighborhoods-buphalo:annotation-processor BuilderService.calls
+*/

--- a/templates/Php81/GeneralActors/V1/PrimaryActorName/BuilderInterface.php
+++ b/templates/Php81/GeneralActors/V1/PrimaryActorName/BuilderInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplateTree\RelativeNamespace\PrimaryActorName;
+
+use Neighborhoods\BuphaloTemplateTree\RelativeNamespace\PrimaryActorNameInterface;
+
+interface BuilderInterface
+{
+    public function build(): PrimaryActorNameInterface;
+
+    public function setRecord(array $record): BuilderInterface;
+}

--- a/templates/Php81/GeneralActors/V1/PrimaryActorName/CollectionInterface.php
+++ b/templates/Php81/GeneralActors/V1/PrimaryActorName/CollectionInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplateTree\RelativeNamespace\PrimaryActorName;
+
+interface CollectionInterface extends \JsonSerializable, \IteratorAggregate
+{
+    public function getIterator(): \Traversable;
+
+    public function toArray(): array;
+}

--- a/templates/Php81/GeneralActors/V1/PrimaryActorName/PrimaryActorName.service.yml
+++ b/templates/Php81/GeneralActors/V1/PrimaryActorName/PrimaryActorName.service.yml
@@ -1,0 +1,5 @@
+services:
+  Neighborhoods\BuphaloTemplateTree\RelativeNamespace\PrimaryActorNameInterface:
+    class: Neighborhoods\BuphaloTemplateTree\RelativeNamespace\PrimaryActorName
+    public: false
+    shared: false

--- a/templates/Php81/GeneralActors/V1/PrimaryActorName/Set.php
+++ b/templates/Php81/GeneralActors/V1/PrimaryActorName/Set.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplateTree\RelativeNamespace\PrimaryActorName;
+
+use Neighborhoods\BuphaloTemplateTree\NamespacedPrimaryActorName;
+
+final class Set implements SetInterface
+{
+    private array $data = [];
+
+    // Initialization Methods
+
+    public function __construct(ParentActorNameInterface ...$values)
+    {
+        $this->add(...$values);
+    }
+
+    public function hydrate(ParentActorNameInterface ...$values): SetInterface
+    {
+        if (!$this->isEmpty()) {
+            throw new \LogicException('String Set is not empty');
+        }
+
+        $this->__construct(...$values);
+
+        return $this;
+    }
+
+
+    // Mutators
+
+    public function add(ParentActorNameInterface ...$values): SetInterface
+    {
+        foreach ($values as $value) {
+            $this->data[$this->getIdentifier($value)] = $value;
+        }
+
+        return $this;
+    }
+
+    public function remove(ParentActorNameInterface ...$values): SetInterface
+    {
+        foreach ($values as $value) {
+            unset($this->data[$this->getIdentifier($value)]);
+        }
+
+        return $this;
+    }
+
+    public function clear(): SetInterface
+    {
+        $this->data = [];
+
+        return $this;
+    }
+
+
+    // Inspectors
+
+    public function contains(ParentActorNameInterface $value): bool
+    {
+        return isset($this->data[$this->getIdentifier($value)]);
+    }
+
+    public function containsAll(ParentActorNameInterface ...$values): bool
+    {
+        foreach ($values as $value) {
+            if (!$this->contains($value)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function containsAny(ParentActorNameInterface ...$values): bool
+    {
+        if (!\count($values)) {
+            throw new \InvalidArgumentException('ContainsAny requires at least one value to search for.');
+        }
+
+        foreach ($values as $value) {
+            if ($this->contains($value)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function count(): int
+    {
+        return \count($this->data);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->count() === 0;
+    }
+
+
+    // Operations that return a new Set
+
+    public function copy(): SetInterface
+    {
+        return new self(...$this);
+    }
+
+    public function diff(SetInterface $other): SetInterface
+    {
+        return $this->filter(
+            static function ($element) use ($other) {
+                return !$other->contains($element);
+            }
+        );
+    }
+
+    public function filter(callable $callback): SetInterface
+    {
+        $filtered = new self();
+
+        foreach($this as $value) {
+            $shouldInclude = $callback($value);
+            if ($shouldInclude === true) {
+                $filtered->add($value);
+            } elseif ($shouldInclude !== false) {
+                throw new \TypeError('Filter callback MUST return boolean');
+            }
+        }
+
+        return $filtered;
+    }
+
+    public function intersect(SetInterface $other): SetInterface
+    {
+        return $this->filter(
+            static function ($element) use ($other) {
+                return $other->contains($element);
+            }
+        );
+    }
+
+    public function map(callable $callback): SetInterface
+    {
+        $mapped = new self();
+        foreach ($this as $value) {
+            $mapped->add($callback($value));
+        }
+
+        return $mapped;
+    }
+
+    public function union(SetInterface $other): SetInterface
+    {
+        $union = $this->copy();
+        $union->add(...$other);
+
+        return $union;
+    }
+
+    public function xor(SetInterface $other): SetInterface
+    {
+        return $this->union($other)->filter(
+            function ($element) use ($other) {
+                return $this->contains($element) xor $other->contains($element);
+            }
+        );
+    }
+
+    // Other Operations
+
+    public function reduce(callable $callback, $initial)
+    {
+        $carry = $initial;
+
+        foreach ($this as $value) {
+            $carry = $callback($carry, $value);
+        }
+
+        return $carry;
+    }
+
+    public function toArray(): array
+    {
+        return array_values($this->data);
+    }
+
+    public function getIterator(): \Traversable
+    {
+        foreach ($this->data as $value) {
+            yield $value;
+        }
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    private function getIdentifier(ParentActorNameInterface $value): string
+    {
+        /** @neighborhoods-buphalo:annotation-processor Set.getIdentifierContent
+         throw new \LogicException("Unimplemented ParentActorName\SetInterface::getIdentifier");
+         */
+    }
+}

--- a/templates/Php81/GeneralActors/V1/PrimaryActorName/SetInterface.php
+++ b/templates/Php81/GeneralActors/V1/PrimaryActorName/SetInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplateTree\RelativeNamespace\PrimaryActorName;
+
+use Neighborhoods\BuphaloTemplateTree\NamespacedPrimaryActorName;
+
+interface SetInterface extends CollectionInterface
+{
+    // Initialization
+    public function hydrate(ParentActorNameInterface ...$values): SetInterface;
+
+    // Mutators
+    public function add(ParentActorNameInterface ...$values): SetInterface;
+
+    public function remove(ParentActorNameInterface ...$values): SetInterface;
+
+    public function clear(): SetInterface;
+
+    // Inspectors
+    public function contains(ParentActorNameInterface $value): bool;
+
+    public function containsAll(ParentActorNameInterface ...$values): bool;
+
+    public function containsAny(ParentActorNameInterface ...$values): bool;
+
+    /* @see \Countable::count() */
+    public function count(): int;
+
+    public function isEmpty(): bool;
+
+    public function copy(): SetInterface;
+
+    public function diff(SetInterface $other): SetInterface;
+
+    public function filter(callable $callback): SetInterface;
+
+    public function intersect(SetInterface $other): SetInterface;
+
+    public function map(callable $callback): SetInterface;
+
+    public function union(SetInterface $other): SetInterface;
+
+    public function xor(SetInterface $other): SetInterface;
+
+    // Operations that return something else
+    public function reduce(callable $callback, $initial);
+}

--- a/templates/Php81/GeneralActors/V1/PrimaryActorNameInterface.php
+++ b/templates/Php81/GeneralActors/V1/PrimaryActorNameInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplateTree\RelativeNamespace;
+
+interface PrimaryActorNameInterface /** @neighborhoods-buphalo:annotation-processor InterfaceExtensions
+    extends \JsonSerializable
+*/
+{
+/** @neighborhoods-buphalo:annotation-processor ClassInterfaceConstantsAndAccessors
+// TODO: Implement accessors.
+ */
+}

--- a/templates/Php81/GeneralActors/V1/SharedActors/AccessorTrait.php
+++ b/templates/Php81/GeneralActors/V1/SharedActors/AccessorTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+/** @noinspection PhpExpressionResultUnusedInspection */ // Typed Properties access to check for initialization
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplateTree\RelativeNamespace\RelativeParentActorClassPath;
+
+/** @neighborhoods-buphalo:annotation-processor AccessorTrait.additional_use_statements
+ */
+
+trait AccessorTrait
+{
+    /** @neighborhoods-buphalo:annotation-processor AccessorTrait.properties_and_methods
+     */
+}

--- a/templates/Php81/GeneralActors/V1/SharedActors/AwareTrait.php
+++ b/templates/Php81/GeneralActors/V1/SharedActors/AwareTrait.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplateTree\RelativeNamespace\RelativeParentActorClassPath;
+
+use Neighborhoods\BuphaloTemplateTree\RelativeNamespace\RelativeParentActorClassPathInterface;
+
+trait AwareTrait
+{
+    private readonly ParentActorNameInterface $NamespacedParentActorName;
+
+    public function setNamespacedParentActorName(ParentActorNameInterface $ParentActorName): self
+    {
+        $this->NamespacedParentActorName = $ParentActorName; // will throw if already set
+
+        return $this;
+    }
+
+    private function getNamespacedParentActorName(): ParentActorNameInterface
+    {
+        return $this->NamespacedParentActorName; // will throw if unset
+    }
+
+    private function hasNamespacedParentActorName(): bool
+    {
+        try {
+            /** @noinspection PhpExpressionResultUnusedInspection */
+            $this->NamespacedParentActorName;
+            return true;
+        } catch (\Error $e) {
+            return false;
+        }
+    }
+}

--- a/templates/Php81/GeneralActors/V1/SharedActors/Factory.php
+++ b/templates/Php81/GeneralActors/V1/SharedActors/Factory.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplateTree\RelativeNamespace\RelativeParentActorClassPath;
+
+use Neighborhoods\BuphaloTemplateTree\RelativeNamespace\RelativeParentActorClassPathInterface;
+
+class Factory implements FactoryInterface
+{
+    use AwareTrait;
+
+    public function create(): ParentActorNameInterface
+    {
+        return clone $this->getNamespacedParentActorName();
+    }
+}

--- a/templates/Php81/GeneralActors/V1/SharedActors/Factory.service.yml
+++ b/templates/Php81/GeneralActors/V1/SharedActors/Factory.service.yml
@@ -1,0 +1,7 @@
+services:
+  Neighborhoods\BuphaloTemplateTree\RelativeNamespace\RelativeParentActorClassPath\FactoryInterface:
+    class: Neighborhoods\BuphaloTemplateTree\RelativeNamespace\RelativeParentActorClassPath\Factory
+    public: false
+    shared: true
+    calls:
+      - [setNamespacedParentActorName, ['@Neighborhoods\BuphaloTemplateTree\RelativeNamespace\RelativeParentActorClassPathInterface']]

--- a/templates/Php81/GeneralActors/V1/SharedActors/FactoryInterface.php
+++ b/templates/Php81/GeneralActors/V1/SharedActors/FactoryInterface.php
@@ -1,0 +1,11 @@
+<?php
+declare(strict_types=1);
+
+namespace Neighborhoods\BuphaloTemplateTree\RelativeNamespace\RelativeParentActorClassPath;
+
+use Neighborhoods\BuphaloTemplateTree\RelativeNamespace\RelativeParentActorClassPathInterface;
+
+interface FactoryInterface
+{
+    public function create(): ParentActorNameInterface;
+}


### PR DESCRIPTION
Committing `fab/` to the repo so that it can be used by other repos more easily.

The idea behind the Class definition files is so that repos that don't feel like they should be tied to Prefab's way of doing things, and especially ones that don't need Prefab's HTTP stack, can still have some nice functionality of defining a class and then defining what actors they want for it.

Example usage in https://github.com/neighborhoods/BuphaloFitness/pull/8